### PR TITLE
Adding the necessary clean-up steps to uninstall Dev Spaces

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -1,5 +1,7 @@
 # Getting Started
 
+## Installation
+
 1. Start by installing the OpenShift GitOps Operator:
 
 ``` 
@@ -20,3 +22,35 @@ oc apply -f deploy/lab-content/apps/
 oc apply -f deploy/lab-content/gitops/argocd.yaml 
 ```
 
+
+## Clean-up
+
+1. Start by deleting the checluster application
+
+```
+oc delete application -n openshift-gitops checluster
+```
+
+2. Delete the OpenShift Dev Spaces Operator
+
+> **TODO:** Avoid the manual clean-up - perhaps by using the `dsc management` tool
+
+```
+> oc delete application -n openshift-gitops devspaces
+> oc delete subscription -n openshift-operators devworkspace-operator-fast-redhat-operators-openshift-marketplace
+> oc delete clusterserviceversion -n openshift-operators devspacesoperator.v3.5.0 \
+                                                         devworkspace-operator.v0.19.1
+> oc delete crd checlusters.org.eclipse.che \
+                devworkspaceoperatorconfigs.controller.devfile.io \
+                devworkspaceroutings.controller.devfile.io \
+                devworkspaces.workspace.devfile.io \
+                devworkspacetemplates.workspace.devfile.io
+> oc delete deployment -n openshift-operators devworkspace-webhook-server
+> oc delete service -n openshift-operators devworkspace-webhookserver
+> oc delete serviceaccount -n openshift-operators devworkspace-webhook-server
+> oc delete clusterrole devworkspace-controller-edit-workspaces \
+                        devworkspace-controller-metrics-reader \
+                        devworkspace-controller-view-workspaces \
+                        devworkspace-webhook-server
+> oc delete clusterrolebinding devworkspace-webhook-server
+```

--- a/deploy/lab-content/apps/checluster.yaml
+++ b/deploy/lab-content/apps/checluster.yaml
@@ -3,6 +3,8 @@ kind: Application
 metadata:
   name: checluster
   namespace: openshift-gitops
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
 spec:
   destination:
     namespace: openshift-devspaces

--- a/deploy/lab-content/apps/devspaces.yaml
+++ b/deploy/lab-content/apps/devspaces.yaml
@@ -5,6 +5,8 @@ metadata:
     argocd.argoproj.io/sync-wave: "-5"
   name: devspaces
   namespace: openshift-gitops
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
 spec:
   destination:
     namespace: openshift-operators


### PR DESCRIPTION
Leaving in `draft` while looking into the use of the [`dsc` management tool](https://access.redhat.com/documentation/en-us/red_hat_openshift_dev_spaces/3.5/html-single/administration_guide/index#installing-the-dsc-management-tool)

@etsauer FYI