### PR TITLE
fix: Add operator group for gitlab

### DIFF
--- a/deploy/lab-content/operators/gitlab/gitlab-operator.yaml
+++ b/deploy/lab-content/operators/gitlab/gitlab-operator.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: operators.coreos.com/v1
 kind: OperatorGroup
 metadata:

--- a/deploy/lab-content/operators/gitlab/gitlab-operator.yaml
+++ b/deploy/lab-content/operators/gitlab/gitlab-operator.yaml
@@ -21,5 +21,5 @@ spec:
   name: gitlab-operator-kubernetes
   source: community-operators
   sourceNamespace: openshift-marketplace
-  startingCSV: gitlab-operator-kubernetes.v0.18.0
+  startingCSV: gitlab-operator-kubernetes.v0.18.2
 

--- a/deploy/lab-content/operators/gitlab/gitlab-operator.yaml
+++ b/deploy/lab-content/operators/gitlab/gitlab-operator.yaml
@@ -4,9 +4,7 @@ kind: OperatorGroup
 metadata:
   name: gitlab
   namespace: gitlab-system
-spec:
-  targetNamespaces:
-  - gitlab-ce
+spec: {}
 ---
 kind: Subscription
 apiVersion: operators.coreos.com/v1alpha1

--- a/deploy/lab-content/operators/gitlab/gitlab-operator.yaml
+++ b/deploy/lab-content/operators/gitlab/gitlab-operator.yaml
@@ -1,3 +1,11 @@
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: gitlab
+  namespace: gitlab-system
+spec:
+  targetNamespaces:
+  - gitlab-ce
 ---
 kind: Subscription
 apiVersion: operators.coreos.com/v1alpha1

--- a/deploy/lab-content/operators/gitlab/gitlab-operator.yaml
+++ b/deploy/lab-content/operators/gitlab/gitlab-operator.yaml
@@ -4,7 +4,9 @@ kind: OperatorGroup
 metadata:
   name: gitlab
   namespace: gitlab-system
-spec: {}
+spec:
+  targetNamespaces:
+  - gitlab-system
 ---
 kind: Subscription
 apiVersion: operators.coreos.com/v1alpha1


### PR DESCRIPTION
fix gitlab operator install by adding an operator group to the namespace