### PR TITLE
Adding gitops label to allow for openshift-authentication sync

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -6,6 +6,7 @@
 
 ``` 
 oc apply -f deploy/bootstrap/operators/openshift-gitops.yaml
+oc label ns/openshift-authentication argocd.argoproj.io/managed-by=openshift-gitops
 oc label ns/openshift-config argocd.argoproj.io/managed-by=openshift-gitops
 ```
 


### PR DESCRIPTION
This will allow OpenShift GitOps to sync objects within the `openshift-authentication` namespace